### PR TITLE
Add build support for both cjs and esm

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -4,4 +4,16 @@ module.exports = {
     "@babel/preset-typescript",
     "@babel/preset-react",
   ],
+  env: {
+    esm: {
+      presets: [
+        [
+          "@babel/env",
+          {
+            modules: false,
+          },
+        ],
+      ],
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   },
   "author": "winkerVSbecks",
   "license": "MIT",
-  "main": "dist/preset",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/ts/index.d.ts",
   "files": [
     "dist/**/*",
     "README.md",
@@ -21,16 +23,19 @@
   ],
   "scripts": {
     "clean": "rimraf ./dist",
-    "buildBabel": "babel ./src --out-dir ./dist --extensions \".js,.jsx,.ts,.tsx\"",
-    "buildTsc": "tsc --declaration --emitDeclarationOnly --outDir ./dist",
-    "build": "concurrently \"yarn run buildBabel\" \"yarn run buildTsc\"",
-    "build:watch": "concurrently \"yarn run buildBabel -- --watch\" \"yarn run buildTsc -- --watch\"",
+    "buildBabel": "concurrently \"yarn buildBabel:cjs\" \"yarn buildBabel:esm\" \"yarn buildTsc\"",
+    "buildBabel:cjs": "babel ./src -d ./dist/cjs --extensions \".js,.jsx,.ts,.tsx\"",
+    "buildBabel:esm": "babel ./src -d ./dist/esm --env-name esm --extensions \".js,.jsx,.ts,.tsx\"",
+    "buildTsc": "tsc --declaration --emitDeclarationOnly --outDir ./dist/ts",
+    "prebuild": "yarn clean",
+    "build": "concurrently \"yarn buildBabel\" \"yarn buildTsc\"",
+    "build:watch": "concurrently \"yarn buildBabel:cjs -- --watch\" \"yarn buildTsc -- --watch\"",
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "start-storybook -p 6006",
-    "start": "concurrently \"yarn run storybook -- --no-manager-cache --quiet\" \"yarn run build:watch\"",
+    "start": "concurrently \"yarn storybook -- --no-manager-cache --quiet\" \"yarn build:watch\"",
     "build-storybook": "build-storybook",
     "prerelease": "node check-metadata.js",
-    "release": "yarn run build && auto shipit"
+    "release": "yarn build && auto shipit"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "author": "winkerVSbecks",
   "license": "MIT",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/preset",
+  "module": "dist/esm/preset",
   "types": "dist/ts/index.d.ts",
   "files": [
     "dist/**/*",
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "clean": "rimraf ./dist",
-    "buildBabel": "concurrently \"yarn buildBabel:cjs\" \"yarn buildBabel:esm\" \"yarn buildTsc\"",
+    "buildBabel": "concurrently \"yarn buildBabel:cjs\" \"yarn buildBabel:esm\"",
     "buildBabel:cjs": "babel ./src -d ./dist/cjs --extensions \".js,.jsx,.ts,.tsx\"",
     "buildBabel:esm": "babel ./src -d ./dist/esm --env-name esm --extensions \".js,.jsx,.ts,.tsx\"",
     "buildTsc": "tsc --declaration --emitDeclarationOnly --outDir ./dist/ts",
@@ -32,7 +32,7 @@
     "build:watch": "concurrently \"yarn buildBabel:cjs -- --watch\" \"yarn buildTsc -- --watch\"",
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "start-storybook -p 6006",
-    "start": "concurrently \"yarn storybook -- --no-manager-cache --quiet\" \"yarn build:watch\"",
+    "start": "concurrently \"yarn build:watch\" \"yarn storybook -- --no-manager-cache --quiet\"",
     "build-storybook": "build-storybook",
     "prerelease": "node check-metadata.js",
     "release": "yarn build && auto shipit"

--- a/preset.js
+++ b/preset.js
@@ -1,1 +1,1 @@
-module.exports = require("./dist/preset")
+module.exports = require("./dist/cjs/preset");

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+if (module && module.hot && module.hot.decline) {
+  module.hot.decline();
+}
+
+// make it work with --isolatedModules
+export default {};

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,0 +1,1 @@
+declare module "global";


### PR DESCRIPTION
### What I did?
* Modified the build setup to generate both esm and cjs output
* Watch task only builds cjs
* Moved types output to `dist/types`
* Added a stub `index.js` file similar to SB monorepo 


closes #6 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.1--canary.8.cce715f.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-measure@1.2.1--canary.8.cce715f.0
  # or 
  yarn add @storybook/addon-measure@1.2.1--canary.8.cce715f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
