### PR TITLE
modify preset to actually support esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,14 @@
   },
   "author": "winkerVSbecks",
   "license": "MIT",
-  "main": "dist/cjs/preset",
-  "module": "dist/esm/preset",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "types": "dist/ts/index.d.ts",
   "files": [
     "dist/**/*",
     "README.md",
-    "*.js"
+    "*.js",
+    "*.d.ts"
   ],
   "scripts": {
     "clean": "rimraf ./dist",
@@ -29,7 +30,7 @@
     "buildTsc": "tsc --declaration --emitDeclarationOnly --outDir ./dist/ts",
     "prebuild": "yarn clean",
     "build": "concurrently \"yarn buildBabel\" \"yarn buildTsc\"",
-    "build:watch": "concurrently \"yarn buildBabel:cjs -- --watch\" \"yarn buildTsc -- --watch\"",
+    "build:watch": "concurrently \"yarn buildBabel:esm -- --watch\" \"yarn buildTsc -- --watch\"",
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "start-storybook -p 6006",
     "start": "concurrently \"yarn build:watch\" \"yarn storybook -- --no-manager-cache --quiet\"",

--- a/preset.js
+++ b/preset.js
@@ -1,1 +1,12 @@
-module.exports = require("./dist/cjs/preset");
+function config(entry = []) {
+  return [...entry, require.resolve("./dist/esm/preset/preview")];
+}
+
+function managerEntries(entry = []) {
+  return [...entry, require.resolve("./dist/esm/preset/manager")];
+}
+
+module.exports = {
+  managerEntries,
+  config,
+};

--- a/src/preset/index.js
+++ b/src/preset/index.js
@@ -1,7 +1,0 @@
-export function config(entry = []) {
-  return [...entry, require.resolve("./preview")]
-}
-
-export function managerEntries(entry = []) {
-  return [...entry, require.resolve("./manager")]
-}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.2--canary.10.1ca5ecf.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-measure@1.2.2--canary.10.1ca5ecf.0
  # or 
  yarn add @storybook/addon-measure@1.2.2--canary.10.1ca5ecf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
