### PR TITLE
Prevent unwanted refresh with unchanged globals

### DIFF
--- a/src/withMeasure.js
+++ b/src/withMeasure.js
@@ -19,7 +19,11 @@ export const withMeasure = (StoryFn, context) => {
 
   const emit = useChannel({});
   const updateGlobals = useCallback(
-    (newGlobals) => emit(UPDATE_GLOBALS, { globals: newGlobals }),
+    (newGlobals) => {
+      if (newGlobals.measureEnabled !== context.globals.measureEnabled) {
+        emit(UPDATE_GLOBALS, { globals: newGlobals })
+      }
+    },
     [emit]
   );
 


### PR DESCRIPTION
The `useHotKey` hook calls the `updateGlobals` function indiscriminately, causing a lot of unnecessary refreshes.
I added a check for preventing unwanted emits.