### PR TITLE
Add optional design tokens to labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ Storybook addon for inspecting layouts and visualizing the box model.
    }
    ```
 
+   Alternatively, you can use your own token scale keys if you also provide a `scaleMap` property, to map dimensions to the appropriate scale:
+
+   ```js
+   {
+     "border.width": [1, 3, 8],
+     size: [8, 16, 32, 64, 128, 256],
+     scaleMap: {
+       border: "border.width",
+       content: "size",
+       margin: "size",
+       padding: "size",
+    },
+   }
+   ```
+
    > **Note**: Only pixel (`px` or unitless), `rem`, and `em` units are currently supported.
 
 ### Inspiration

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Storybook addon for inspecting layouts and visualizing the box model.
    }
    ```
 
-   > **Note**: Only pixel units are currently supported.
+   > **Note**: Only pixel (`px` or unitless), `rem`, and `em` units are currently supported.
 
 ### Inspiration
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Storybook addon for inspecting layouts and visualizing the box model.
    {
      borderWidths: { sm: 1, md: 3, lg: 8 },
      sizes: { sm: 16, md: 32, lg: 64, xl: 128, xxl: 256 },
-     space: { sm: 8, md: 16, lg: 32, xl: 64 },
+     space: { xxs: 4, xs: 8, sm: 16, md: 32, lg: 64 },
    }
    ```
 
@@ -50,7 +50,7 @@ Storybook addon for inspecting layouts and visualizing the box model.
    {
      borderWidths: [1, 3, 8],
      sizes: [16, 32, 64, 128, 256],
-     space: [8, 16, 32, 64],
+     space: [4, 8, 16, 32, 64],
    }
    ```
 
@@ -59,7 +59,7 @@ Storybook addon for inspecting layouts and visualizing the box model.
    ```js
    {
      "border.width": [1, 3, 8],
-     size: [8, 16, 32, 64, 128, 256],
+     size: [4, 8, 16, 32, 64, 128, 256],
      scaleMap: {
        border: "border.width",
        content: "size",

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Storybook addon for inspecting layouts and visualizing the box model.
 
 3. Storybook will display the dimensions of the selected element—margin, padding, border, width and height—in pixels.
 
+4. If you provide design tokens, the relevant token name will display alongside the measurement.
+
 ![](https://user-images.githubusercontent.com/42671/119589961-dff9b380-bda1-11eb-9550-7ae28bc70bf4.gif)
 
 ## Usage
@@ -18,17 +20,41 @@ Storybook addon for inspecting layouts and visualizing the box model.
 
 2. Install the addon:
 
-```sh
-npm i -D @storybook/addon-measure
-```
+   ```sh
+   npm i -D @storybook/addon-measure
+   ```
 
 3. Add `"@storybook/addon-measure"` to the addons array in your `.storybook/main.js`:
 
-```js
-module.exports = {
-  addons: ["@storybook/addon-measure"],
-};
-```
+   ```js
+   module.exports = {
+     addons: ["@storybook/addon-measure"],
+   };
+   ```
+
+4. (Optional) Provide design tokens
+
+   Set the `tokens` parameter ([how?](https://storybook.js.org/docs/react/writing-stories/parameters)) to an object with this shape:
+
+   ```js
+   {
+     borderWidths: { sm: 1, md: 3, lg: 8 },
+     sizes: { sm: 16, md: 32, lg: 64, xl: 128, xxl: 256 },
+     space: { sm: 8, md: 16, lg: 32, xl: 64 },
+   }
+   ```
+
+   Token scale arrays are also supported:
+
+   ```js
+   {
+     borderWidths: [1, 3, 8],
+     sizes: [16, 32, 64, 128, 256],
+     space: [8, 16, 32, 64],
+   }
+   ```
+
+   > **Note**: Only pixel units are currently supported.
 
 ### Inspiration
 

--- a/src/box-model/labels.js
+++ b/src/box-model/labels.js
@@ -1,3 +1,5 @@
+import { tokenizeLabels } from "./tokenize";
+
 const colors = {
   margin: "#f6b26b",
   border: "#ffe599",
@@ -237,7 +239,15 @@ function drawStack(context, dimensions, stack, external) {
   });
 }
 
-export function labelStacks(context, dimensions, labels, externalLabels) {
+export function labelStacks(
+  context,
+  dimensions,
+  labelsIn,
+  externalLabels,
+  tokens
+) {
+  const labels = tokens ? tokenizeLabels(labelsIn, tokens) : labelsIn;
+
   const stacks = labels.reduce((acc, l) => {
     if (!acc.hasOwnProperty(l.position)) {
       acc[l.position] = [];

--- a/src/box-model/labels.js
+++ b/src/box-model/labels.js
@@ -246,7 +246,9 @@ export function labelStacks(
   externalLabels,
   tokens
 ) {
-  const labels = tokens ? tokenizeLabels(labelsIn, tokens) : labelsIn;
+  const labels = tokens
+    ? tokenizeLabels(dimensions, labelsIn, tokens)
+    : labelsIn;
 
   const stacks = labels.reduce((acc, l) => {
     if (!acc.hasOwnProperty(l.position)) {

--- a/src/box-model/tokenize.js
+++ b/src/box-model/tokenize.js
@@ -1,6 +1,6 @@
 import { pxToNumber, round } from "../util";
 
-const scaleMap = {
+const defaultScaleMap = {
   border: "borderWidths",
   content: "sizes",
   margin: "space",
@@ -45,18 +45,20 @@ function normalizeValue(value, elementFontSize) {
   return newValue.toString();
 }
 
-export function tokenizeLabels({ fontSize: elementFontSize }, labels, tokens) {
+export function tokenizeLabels(
+  { fontSize: elementFontSize },
+  labels,
+  { scaleMap = defaultScaleMap, ...tokens }
+) {
   return labels.map((label) => {
     const { text, type } = label;
     const scaleKey = scaleMap[type];
     const scale = scaleKey && tokens[scaleKey];
 
     if (!scale) {
-      // TODO: Warn about bad schema?
       return label;
     }
 
-    // TODO: memoize?
     const scaleLookup = Object.entries(scale).reduce(
       (acc, [tokenKey, value]) => {
         const lookupKey = normalizeValue(value, elementFontSize);

--- a/src/box-model/tokenize.js
+++ b/src/box-model/tokenize.js
@@ -1,9 +1,19 @@
+import { pxToNumber, round } from "../util";
+
 const scaleMap = {
   border: "borderWidths",
   content: "sizes",
   margin: "space",
   padding: "space",
 };
+
+function remToNumber(value) {
+  return round(parseFloat(value.replace("rem", "")));
+}
+
+function emToNumber(value) {
+  return round(parseFloat(value.replace("em", "")));
+}
 
 function tokenizeText(scaleLookup, text, type) {
   if (type === "content") {
@@ -19,7 +29,23 @@ function tokenizeText(scaleLookup, text, type) {
   }
 }
 
-export function tokenizeLabels(labels, tokens) {
+function normalizeValue(value, elementFontSize) {
+  let newValue = value;
+  if (typeof value === "string") {
+    if (value.endsWith("px")) {
+      newValue = pxToNumber(value);
+    } else if (value.endsWith("rem")) {
+      const rootFontSize = getComputedStyle(document.documentElement).fontSize;
+      newValue = remToNumber(value) * pxToNumber(rootFontSize);
+    } else if (value.endsWith("em")) {
+      newValue = emToNumber(value) * elementFontSize;
+    }
+  }
+
+  return newValue.toString();
+}
+
+export function tokenizeLabels({ fontSize: elementFontSize }, labels, tokens) {
   return labels.map((label) => {
     const { text, type } = label;
     const scaleKey = scaleMap[type];
@@ -33,7 +59,8 @@ export function tokenizeLabels(labels, tokens) {
     // TODO: memoize?
     const scaleLookup = Object.entries(scale).reduce(
       (acc, [tokenKey, value]) => {
-        acc[value.toString()] = Array.isArray(scale)
+        const lookupKey = normalizeValue(value, elementFontSize);
+        acc[lookupKey] = Array.isArray(scale)
           ? `${scaleKey}[${tokenKey}]`
           : `${scaleKey}.${tokenKey}`;
         return acc;

--- a/src/box-model/tokenize.js
+++ b/src/box-model/tokenize.js
@@ -62,9 +62,11 @@ export function tokenizeLabels(
     const scaleLookup = Object.entries(scale).reduce(
       (acc, [tokenKey, value]) => {
         const lookupKey = normalizeValue(value, elementFontSize);
-        acc[lookupKey] = Array.isArray(scale)
-          ? `${scaleKey}[${tokenKey}]`
-          : `${scaleKey}.${tokenKey}`;
+        if (!acc.hasOwnProperty(lookupKey)) {
+          acc[lookupKey] = Array.isArray(scale)
+            ? `${scaleKey}[${tokenKey}]`
+            : `${scaleKey}.${tokenKey}`;
+        }
         return acc;
       },
       {}

--- a/src/box-model/tokenize.js
+++ b/src/box-model/tokenize.js
@@ -1,0 +1,49 @@
+const scaleMap = {
+  border: "borderWidths",
+  content: "sizes",
+  margin: "space",
+  padding: "space",
+};
+
+function tokenizeText(scaleLookup, text, type) {
+  if (type === "content") {
+    const [width, , height] = text.split(" ");
+
+    const widthText = tokenizeText(scaleLookup, width);
+    const heightText = tokenizeText(scaleLookup, height);
+
+    return `${widthText} x ${heightText}`;
+  } else {
+    const token = scaleLookup[text.toString()];
+    return token ? `${text} (${token})` : text;
+  }
+}
+
+export function tokenizeLabels(labels, tokens) {
+  return labels.map((label) => {
+    const { text, type } = label;
+    const scaleKey = scaleMap[type];
+    const scale = scaleKey && tokens[scaleKey];
+
+    if (!scale) {
+      // TODO: Warn about bad schema?
+      return label;
+    }
+
+    // TODO: memoize?
+    const scaleLookup = Object.entries(scale).reduce(
+      (acc, [tokenKey, value]) => {
+        acc[value.toString()] = Array.isArray(scale)
+          ? `${scaleKey}[${tokenKey}]`
+          : `${scaleKey}.${tokenKey}`;
+        return acc;
+      },
+      {}
+    );
+
+    return {
+      ...label,
+      text: tokenizeText(scaleLookup, text, type),
+    };
+  });
+}

--- a/src/box-model/visualizer.js
+++ b/src/box-model/visualizer.js
@@ -1,6 +1,7 @@
 /**
  * Based on https://gist.github.com/awestbro/e668c12662ad354f02a413205b65fce7
  */
+import { pxToNumber, round } from "../util";
 import { draw } from "./canvas";
 import { labelStacks } from "./labels";
 
@@ -12,14 +13,6 @@ const colors = {
 };
 
 const SMALL_NODE_SIZE = 30;
-
-function pxToNumber(px) {
-  return parseInt(px.replace("px", ""));
-}
-
-function round(value) {
-  return Number.isInteger(value) ? value : value.toFixed(2);
-}
 
 function floatingAlignment(extremities) {
   const windowExtremities = {
@@ -66,6 +59,7 @@ function measureElement(element) {
     borderTopWidth,
     borderLeftWidth,
     borderRightWidth,
+    fontSize,
   } = style;
 
   top = top + window.scrollY;
@@ -111,6 +105,7 @@ function measureElement(element) {
     right,
     width,
     height,
+    fontSize: pxToNumber(fontSize),
     extremities,
     floatingAlignment: floatingAlignment(extremities),
   };

--- a/src/box-model/visualizer.js
+++ b/src/box-model/visualizer.js
@@ -297,7 +297,7 @@ function drawContent(context, { padding, border, width, height, top, left }) {
   ];
 }
 
-function drawBoxModel(element) {
+function drawBoxModel(element, tokens) {
   return (context) => {
     if (element && context) {
       const dimensions = measureElement(element);
@@ -315,12 +315,13 @@ function drawBoxModel(element) {
         context,
         dimensions,
         [...contentLabels, ...paddingLabels, ...borderLabels, ...marginLabels],
-        externalLabels
+        externalLabels,
+        tokens
       );
     }
   };
 }
 
-export function drawSelectedElement(element) {
-  draw(drawBoxModel(element));
+export function drawSelectedElement(element, tokens) {
+  draw(drawBoxModel(element, tokens));
 }

--- a/src/util.js
+++ b/src/util.js
@@ -26,3 +26,11 @@ export const deepElementFromPoint = (x, y) => {
 
   return shadowElement || element;
 };
+
+export function pxToNumber(value) {
+  return parseInt(value.replace("px", ""));
+}
+
+export function round(value) {
+  return Number.isInteger(value) ? value : value.toFixed(2);
+}

--- a/src/withMeasure.js
+++ b/src/withMeasure.js
@@ -7,13 +7,27 @@ import { deepElementFromPoint } from "./util";
 let nodeAtPointerRef;
 const pointer = { x: 0, y: 0 };
 
-function findAndDrawElement(x, y) {
+function findAndDrawElement(x, y, tokens) {
   nodeAtPointerRef = deepElementFromPoint(x, y);
-  drawSelectedElement(nodeAtPointerRef);
+  drawSelectedElement(nodeAtPointerRef, tokens);
 }
 
 export const withMeasure = (StoryFn, context) => {
   const { measureEnabled } = context.globals;
+  const {
+    measure: measureParam = {},
+    tokens: tokensParam,
+  } = context.parameters;
+
+  const measureTokensParam = measureParam.tokens;
+  let tokens;
+  if (measureTokensParam === false) {
+    tokens = false;
+  } else if (measureTokensParam && measureTokensParam.disable) {
+    tokens = false;
+  } else {
+    tokens = tokensParam;
+  }
 
   useEffect(() => {
     const onMouseMove = (event) => {
@@ -35,7 +49,7 @@ export const withMeasure = (StoryFn, context) => {
     const onMouseOver = (event) => {
       window.requestAnimationFrame(() => {
         event.stopPropagation();
-        findAndDrawElement(event.clientX, event.clientY);
+        findAndDrawElement(event.clientX, event.clientY, tokens);
       });
     };
 
@@ -50,14 +64,14 @@ export const withMeasure = (StoryFn, context) => {
       init();
       window.addEventListener("resize", onResize);
       // Draw the element below the pointer when first enabled
-      findAndDrawElement(pointer.x, pointer.y);
+      findAndDrawElement(pointer.x, pointer.y, tokens);
     }
 
     return () => {
       window.removeEventListener("resize", onResize);
       destroy();
     };
-  }, [measureEnabled]);
+  }, [measureEnabled, tokens]);
 
   return StoryFn();
 };

--- a/stories/DesignTokens.stories.js
+++ b/stories/DesignTokens.stories.js
@@ -86,6 +86,20 @@ EmUnits.parameters = {
   },
 };
 
+export const CustomScaleMap = Template.bind({});
+CustomScaleMap.parameters = {
+  tokens: {
+    "border.width": [1, 3, 8],
+    size: [8, 16, 32, 64, 128, 256],
+    scaleMap: {
+      border: "border.width",
+      content: "size",
+      margin: "size",
+      padding: "size",
+    },
+  },
+};
+
 export const DisabledWithFalse = Template.bind({});
 DisabledWithFalse.storyName = "Disabled (with false)";
 DisabledWithFalse.parameters = {

--- a/stories/DesignTokens.stories.js
+++ b/stories/DesignTokens.stories.js
@@ -37,7 +37,7 @@ ThemeUIArrayScale.parameters = {
   tokens: {
     borderWidths: [1, 3, 8],
     sizes: [16, 32, 64, 128, 256],
-    space: [8, 16, 32, 64],
+    space: [4, 8, 16, 32, 64],
   },
 };
 
@@ -46,7 +46,7 @@ ThemeUIObjectScale.parameters = {
   tokens: {
     borderWidths: { sm: 1, md: 3, lg: 8 },
     sizes: { sm: 16, md: 32, lg: 64, xl: 128, xxl: 256 },
-    space: { sm: 8, md: 16, lg: 32, xl: 64 },
+    space: { xxs: 4, xs: 8, sm: 16, md: 32, lg: 64 },
   },
 };
 
@@ -55,7 +55,7 @@ PxUnits.parameters = {
   tokens: {
     borderWidths: { sm: "1px", md: "3px", lg: "8px" },
     sizes: { sm: "16px", md: "32px", lg: "64px", xl: "128px", xxl: "256px" },
-    space: { sm: "8px", md: "16px", lg: "32px", xl: "64px" },
+    space: { xxs: "4px", xs: "8px", sm: "16px", md: "32px", lg: "64px" },
   },
 };
 
@@ -64,7 +64,7 @@ RemUnits.parameters = {
   tokens: {
     borderWidths: { sm: 1, md: 3, lg: 8 },
     sizes: { sm: "1rem", md: "2rem", lg: "4rem", xl: "8rem", xxl: "16rem" },
-    space: { sm: "0.5rem", md: "1rem", lg: "2rem", xl: "4rem" },
+    space: { xxs: "0.25rem", xs: "0.5rem", sm: "1rem", md: "2rem", lg: "4rem" },
   },
 };
 
@@ -82,7 +82,7 @@ EmUnits.parameters = {
   tokens: {
     borderWidths: { sm: 1, md: 3, lg: 8 },
     sizes: { sm: "1em", md: "2em", lg: "4em", xl: "8em", xxl: "16em" },
-    space: { sm: "0.5em", md: "1em", lg: "2em", xl: "4em" },
+    space: { xxs: "0.25em", xs: "0.5em", sm: "1em", md: "2em", lg: "4em" },
   },
 };
 
@@ -90,7 +90,7 @@ export const CustomScaleMap = Template.bind({});
 CustomScaleMap.parameters = {
   tokens: {
     "border.width": [1, 3, 8],
-    size: [8, 16, 32, 64, 128, 256],
+    size: [4, 8, 16, 32, 64, 128, 256],
     scaleMap: {
       border: "border.width",
       content: "size",
@@ -103,7 +103,7 @@ CustomScaleMap.parameters = {
 export const DuplicateScaleValues = Template.bind({});
 DuplicateScaleValues.parameters = {
   tokens: {
-    space: { md: 16, lg1: 32, lg2: 32 },
+    space: { sm: 16, md1: 32, md2: 32 },
   },
 };
 
@@ -114,7 +114,7 @@ DisabledWithFalse.parameters = {
   tokens: {
     borderWidths: { sm: 1, md: 3, lg: 8 },
     sizes: { sm: 16, md: 32, lg: 64, xl: 128, xxl: 256 },
-    space: { sm: 8, md: 16, lg: 32, xl: 64 },
+    space: { xxs: 4, xs: 8, sm: 16, md: 32, lg: 64 },
   },
 };
 
@@ -125,6 +125,6 @@ DisabledWithDisableTrue.parameters = {
   tokens: {
     borderWidths: { sm: 1, md: 3, lg: 8 },
     sizes: { sm: 16, md: 32, lg: 64, xl: 128, xxl: 256 },
-    space: { sm: 8, md: 16, lg: 32, xl: 64 },
+    space: { xxs: 4, xs: 8, sm: 16, md: 32, lg: 64 },
   },
 };

--- a/stories/DesignTokens.stories.js
+++ b/stories/DesignTokens.stories.js
@@ -50,6 +50,42 @@ ThemeUIObjectScale.parameters = {
   },
 };
 
+export const PxUnits = Template.bind({});
+PxUnits.parameters = {
+  tokens: {
+    borderWidths: { sm: "1px", md: "3px", lg: "8px" },
+    sizes: { sm: "16px", md: "32px", lg: "64px", xl: "128px", xxl: "256px" },
+    space: { sm: "8px", md: "16px", lg: "32px", xl: "64px" },
+  },
+};
+
+export const RemUnits = Template.bind({});
+RemUnits.parameters = {
+  tokens: {
+    borderWidths: { sm: 1, md: 3, lg: 8 },
+    sizes: { sm: "1rem", md: "2rem", lg: "4rem", xl: "8rem", xxl: "16rem" },
+    space: { sm: "0.5rem", md: "1rem", lg: "2rem", xl: "4rem" },
+  },
+};
+
+export const EmUnits = Template.bind({});
+EmUnits.decorators = [
+  (Story) => (
+    // This will make the associated sizes or space token be "one step down" on
+    // the scale, relative to RemUnits
+    <div style={{ fontSize: "2rem" }}>
+      <Story />
+    </div>
+  ),
+];
+EmUnits.parameters = {
+  tokens: {
+    borderWidths: { sm: 1, md: 3, lg: 8 },
+    sizes: { sm: "1em", md: "2em", lg: "4em", xl: "8em", xxl: "16em" },
+    space: { sm: "0.5em", md: "1em", lg: "2em", xl: "4em" },
+  },
+};
+
 export const DisabledWithFalse = Template.bind({});
 DisabledWithFalse.storyName = "Disabled (with false)";
 DisabledWithFalse.parameters = {

--- a/stories/DesignTokens.stories.js
+++ b/stories/DesignTokens.stories.js
@@ -100,6 +100,13 @@ CustomScaleMap.parameters = {
   },
 };
 
+export const DuplicateScaleValues = Template.bind({});
+DuplicateScaleValues.parameters = {
+  tokens: {
+    space: { md: 16, lg1: 32, lg2: 32 },
+  },
+};
+
 export const DisabledWithFalse = Template.bind({});
 DisabledWithFalse.storyName = "Disabled (with false)";
 DisabledWithFalse.parameters = {

--- a/stories/DesignTokens.stories.js
+++ b/stories/DesignTokens.stories.js
@@ -1,0 +1,73 @@
+import React from "react";
+import { Visualization } from "./Visualization";
+
+export default {
+  title: "Visualizations/DesignTokens",
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+const defaultRender = (ref) => (
+  <div
+    ref={ref}
+    style={{
+      outline: "1px solid black",
+      width: 256,
+      height: 255,
+      border: "8px solid transparent",
+      borderBottomWidth: 7,
+      padding: "16px 16px 15px 16px",
+      margin: "32px 32px 31px 32px",
+    }}
+  ></div>
+);
+
+const Template = ({ render = defaultRender, ...args }, { parameters }) => (
+  <Visualization
+    {...args}
+    render={render}
+    measure={parameters.measure}
+    tokens={parameters.tokens}
+  />
+);
+
+export const ThemeUIArrayScale = Template.bind({});
+ThemeUIArrayScale.parameters = {
+  tokens: {
+    borderWidths: [1, 3, 8],
+    sizes: [16, 32, 64, 128, 256],
+    space: [8, 16, 32, 64],
+  },
+};
+
+export const ThemeUIObjectScale = Template.bind({});
+ThemeUIObjectScale.parameters = {
+  tokens: {
+    borderWidths: { sm: 1, md: 3, lg: 8 },
+    sizes: { sm: 16, md: 32, lg: 64, xl: 128, xxl: 256 },
+    space: { sm: 8, md: 16, lg: 32, xl: 64 },
+  },
+};
+
+export const DisabledWithFalse = Template.bind({});
+DisabledWithFalse.storyName = "Disabled (with false)";
+DisabledWithFalse.parameters = {
+  measure: { tokens: false },
+  tokens: {
+    borderWidths: { sm: 1, md: 3, lg: 8 },
+    sizes: { sm: 16, md: 32, lg: 64, xl: 128, xxl: 256 },
+    space: { sm: 8, md: 16, lg: 32, xl: 64 },
+  },
+};
+
+export const DisabledWithDisableTrue = Template.bind({});
+DisabledWithDisableTrue.storyName = "Disabled (with { disable: true })";
+DisabledWithDisableTrue.parameters = {
+  measure: { tokens: { disable: true } },
+  tokens: {
+    borderWidths: { sm: 1, md: 3, lg: 8 },
+    sizes: { sm: 16, md: 32, lg: 64, xl: 128, xxl: 256 },
+    space: { sm: 8, md: 16, lg: 32, xl: 64 },
+  },
+};

--- a/stories/Visualization.js
+++ b/stories/Visualization.js
@@ -2,13 +2,27 @@ import React, { useEffect, useRef } from "react";
 import { drawSelectedElement } from "../src/box-model/visualizer";
 import { init, destroy } from "../src/box-model/canvas";
 
-export const Visualization = ({ render }) => {
+export const Visualization = ({
+  render,
+  measure: measureParam = {},
+  tokens: tokensParam,
+}) => {
   const element = useRef(null);
+
+  const measureTokensParam = measureParam.tokens;
+  let tokens;
+  if (measureTokensParam === false) {
+    tokens = false;
+  } else if (measureTokensParam && measureTokensParam.disable) {
+    tokens = false;
+  } else {
+    tokens = tokensParam;
+  }
 
   useEffect(() => {
     if (element.current) {
       init();
-      drawSelectedElement(element.current);
+      drawSelectedElement(element.current, tokens);
     }
 
     return () => {


### PR DESCRIPTION
### Description

- Add ability to define design tokens with `parameters.tokens`
- Look up pixel value of measurement in tokens and display associated token inside label
- Tokens schema matches [Theme UI's theme spec](https://theme-ui.com/theme-spec) and can have px (unitless), `'px'`, `'rem'`, or `'em'` units
- If consumer tokens use a different schema, they can provide a `scaleMap` to map their token scales onto the appropriate dimension
- Add stories
- Update README

![Screenshot showing labels for margin-top, border-top-width, and padding-top, with pixel values and associated token names](https://user-images.githubusercontent.com/486540/124490609-8a84cf00-dd6f-11eb-95ea-eb504b8ecc65.png)

### Motivation

When comparing a story side-by-side with a design, dimensions are often spec’d by referencing a design token value, rather than the resultant pixel size. This work allows for a more direct comparison, and further encourages a shared language to describe design across disciplines.

### How to Test

1. Check out this branch
1. Confirm behavior of all new stories
1. (If a draft PR creates a canary) Install the canary package in a new project, provide design tokens, and confirm behavior.

### Follow-up

I'm submitting this PR as a draft because I think significant questions and work remain before it's ready for release. Specifically:

1. I assumed other parts of Storybook would find utility in accessing design tokens. That assumption should be checked, and, if incorrect, this PR should be updated to look for tokens at `parameters.measure.tokens`.
    1. There's also currently an API for providing tokens, but _not_ displaying them within this addon. That could be removed, if we make the above change.

1. The left/right labels become really wide with tokens inside. In addition, they start colliding with the interior content label and are likely to be cut off by the viewport:
   
   ![Screenshot showing labels for margin-right, border-right-width, and padding-right, with pixel values and associated token names](https://user-images.githubusercontent.com/486540/124491643-be142900-dd70-11eb-8ad3-86ffd07704e2.png)
   
   I started adjusting the `offset` and `overlapAdjustment` logic to accommodate this, but I think it would require a significant refactor, and should likely be tackled in a follow-up PR. I sketched two alternative placement ideas:
   
   A. Labels horizontally centered with relevant dimension and stacked vertically
   ![Screenshot showing first alternative label placement idea](https://user-images.githubusercontent.com/486540/124492133-4abee700-dd71-11eb-8331-5c9d851cc511.png)
   _This likely avoids the viewport cutoff issue, but as you can see, can still collide with the interior content label._

   B. Labels starting at their relevant dimension's interior edge and stacked vertically
   ![Screenshot showing second alternative label placement idea](https://user-images.githubusercontent.com/486540/124492499-c6b92f00-dd71-11eb-80d2-3f19cd6c5a0d.png)
   _This prevents collision with the interior content label, but as it extends farther outside the element's boundary, it may be cutoff by the viewport._
   
   With either approach, left/right labels should likely only display with the alternative placement when design tokens are enabled.

1. Once this is truly ready for release, a new animated graphic for the README should be made, demo'ing the design token feature.
